### PR TITLE
Add duration_pct_rank feature

### DIFF
--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import pipeline
+
+
+def test_preprocess_adds_duration_pct_rank():
+    df = pd.DataFrame({
+        'Id': [1, 2, 3, 4],
+        'ranker_id': [1, 1, 2, 2],
+        'selected': [0, 1, 0, 1],
+        'totalPrice': [100, 150, 200, 120],
+        'taxes': [10, 15, 20, 12],
+        'legs0_duration': [60, 80, 90, 100],
+        'legs1_duration': [70, 60, 80, 90],
+        'legs1_segments0_departureFrom_airport_iata': ['A', 'B', 'C', 'D'],
+        'legs0_segments0_departureFrom_airport_iata': ['X', 'Y', 'Z', 'W'],
+        'frequentFlyer': ['SU', 'S7', 'U6', 'TK'],
+        'legs0_segments0_marketingCarrier_code': ['SU', 'SU', 'U6', 'TK'],
+        'legs1_segments0_marketingCarrier_code': ['SU', 'SU', 'U6', 'TK'],
+        'legs0_segments0_baggageAllowance_quantity': [1, 0, 1, 0],
+        'legs1_segments0_baggageAllowance_quantity': [0, 1, 0, 1],
+        'miniRules0_monetaryAmount': [0, 10, 0, 5],
+        'miniRules1_monetaryAmount': [5, 0, 10, 0],
+        'searchRoute': ['MOWLED/LEDMOW'] * 4,
+        'isVip': [0, 1, 0, 1],
+        'pricingInfo_isAccessTP': [1, 0, 1, 0],
+        'legs0_segments0_cabinClass': [1, 1, 1, 1],
+        'legs1_segments0_cabinClass': [2, 2, 2, 2],
+    })
+
+    processed = pipeline.preprocess_dataframe(df.copy(), is_train=True)
+    assert 'duration_pct_rank' in processed.columns

--- a/utils.py
+++ b/utils.py
@@ -291,6 +291,7 @@ def create_features(df):
     feat["price_rank"]        = grp["totalPrice"].rank()
     feat["price_pct_rank"]    = grp["totalPrice"].rank(pct=True)
     feat["duration_rank"]     = grp["total_duration"].rank()
+    feat["duration_pct_rank"] = grp["total_duration"].rank(pct=True)
     feat["is_cheapest"]       = (grp["totalPrice"].transform("min") == df["totalPrice"]).astype("int8")
     feat["is_most_expensive"] = (grp["totalPrice"].transform("max") == df["totalPrice"]).astype("int8")
     feat["price_from_median"] = grp["totalPrice"].transform(lambda x: (x - x.median()) / (x.std() + 1))


### PR DESCRIPTION
## Summary
- extend `create_features` with `duration_pct_rank`
- test that preprocessing includes the new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d2117a348333a9c3a9c01f5ee3b6