### PR TITLE
Keep dep_is_hub feature

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -129,7 +129,6 @@ def prepare_matrices(train_df_processed, test_df_processed):
         'price_rank', 'totalPrice_rank_in_group', 'price_from_median',
         'tax_percentage',
         'n_segments_leg0', 'n_segments_leg1',
-        'dep_is_hub',
         'group_size_log', 'has_access_tp',
         'is_round_trip',
     ]


### PR DESCRIPTION
## Summary
- keep `dep_is_hub` feature rather than dropping it
- update dependencies for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d3e858e88333bf3261ad807b40ba