### PR TITLE
Refactor segment feature names

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -128,7 +128,7 @@ def prepare_matrices(train_df_processed, test_df_processed):
         'has_fees', 'has_baggage',
         'price_rank', 'totalPrice_rank_in_group', 'price_from_median',
         'tax_percentage',
-        'n_segments_leg0', 'n_segments_leg1',
+        'num_segments_leg0', 'num_segments_leg1',
         'dep_is_hub',
         'group_size_log', 'has_access_tp',
         'is_round_trip',


### PR DESCRIPTION
## Summary
- rely on `num_segments_leg0` and `num_segments_leg1` from `create_remaining_features`
- compute direct flight flags after segment counts
- adjust `DROP_COLS` in pipeline
- update missing-value rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d3dc2408833393b02bc43f9063c5