### PR TITLE
Add price and duration diff features

### DIFF
--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -29,3 +29,5 @@ def test_preprocess_adds_duration_pct_rank():
 
     processed = pipeline.preprocess_dataframe(df.copy(), is_train=True)
     assert 'duration_pct_rank' in processed.columns
+    assert 'price_diff_from_median' in processed.columns
+    assert 'duration_diff_from_min' in processed.columns

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,3 +118,37 @@ def test_create_initial_datetime_features_normalises_offsets():
     out = utils.create_initial_datetime_features(df.copy())
     ts = out.loc[0, "legs0_departureAt"]
     assert ts.utcoffset().total_seconds() == 5 * 3600
+
+
+def test_create_features_price_and_duration_diffs():
+    df = pd.DataFrame({
+        'Id': [1, 2, 3, 4],
+        'ranker_id': [1, 1, 2, 2],
+        'totalPrice': [100, 150, 200, 120],
+        'taxes': [10, 15, 20, 12],
+        'legs0_duration': [60, 80, 90, 100],
+        'legs1_duration': [70, 60, 80, 90],
+        'legs1_segments0_departureFrom_airport_iata': ['A', 'B', 'C', 'D'],
+        'legs0_segments0_departureFrom_airport_iata': ['X', 'Y', 'Z', 'W'],
+        'frequentFlyer': ['SU', 'S7', 'U6', 'TK'],
+        'legs0_segments0_marketingCarrier_code': ['SU', 'SU', 'U6', 'TK'],
+        'legs1_segments0_marketingCarrier_code': ['SU', 'SU', 'U6', 'TK'],
+        'legs0_segments0_baggageAllowance_quantity': [1, 0, 1, 0],
+        'legs1_segments0_baggageAllowance_quantity': [0, 1, 0, 1],
+        'miniRules0_monetaryAmount': [0, 10, 0, 5],
+        'miniRules1_monetaryAmount': [5, 0, 10, 0],
+        'searchRoute': ['MOWLED/LEDMOW'] * 4,
+        'isVip': [0, 1, 0, 1],
+        'pricingInfo_isAccessTP': [1, 0, 1, 0],
+        'legs0_segments0_cabinClass': [1, 1, 1, 1],
+        'legs1_segments0_cabinClass': [2, 2, 2, 2],
+    })
+
+    out = utils.create_features(df.copy())
+
+    assert 'price_diff_from_median' in out.columns
+    assert 'duration_diff_from_min' in out.columns
+    expected_price_diff = [-25.0, 25.0, 40.0, -40.0]
+    expected_dur_diff = [0.0, 10.0, 0.0, 20.0]
+    assert out['price_diff_from_median'].tolist() == expected_price_diff
+    assert out['duration_diff_from_min'].tolist() == expected_dur_diff

--- a/utils.py
+++ b/utils.py
@@ -349,6 +349,12 @@ def create_features(df):
     feat["price_pct_rank"]    = grp["totalPrice"].rank(pct=True)
     feat["duration_rank"]     = grp["total_duration"].rank()
     feat["duration_pct_rank"] = grp["total_duration"].rank(pct=True)
+    feat["price_diff_from_median"] = (
+        df["totalPrice"] - grp["totalPrice"].transform("median")
+    )
+    feat["duration_diff_from_min"] = (
+        df["total_duration"] - grp["total_duration"].transform("min")
+    )
     feat["is_cheapest"]       = (grp["totalPrice"].transform("min") == df["totalPrice"]).astype("int8")
     feat["is_most_expensive"] = (grp["totalPrice"].transform("max") == df["totalPrice"]).astype("int8")
     ff = df["frequentFlyer"].fillna("").astype(str)


### PR DESCRIPTION
## Summary
- compute price_diff_from_median and duration_diff_from_min in `create_features`
- test new feature calculations
- verify pipeline preprocessing exposes the new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f4bd99b0833394497ba80d4f0f6b