### PR TITLE
Move unused debug functions to new module

### DIFF
--- a/debug_utils.py
+++ b/debug_utils.py
@@ -1,0 +1,29 @@
+"""Helper functions used for ad-hoc debugging and data checks."""
+
+from pandas import DataFrame
+
+
+def dur_stats(df: DataFrame) -> None:
+    """Print basic statistics for duration columns."""
+    for col in ["legs0_duration", "legs1_duration"]:
+        print(
+            col,
+            "\u2192", df[col].dtype,
+            "| NaN:", df[col].isna().mean(),
+            "| 0.0:", (df[col] == 0).mean(),
+            "| -1:", (df[col] == -1).mean(),
+            "| min:", df[col].min(),
+            "| max:", df[col].max(),
+        )
+
+
+def check_rank_permutation(group: DataFrame) -> bool:
+    """Return ``True`` if ``group['selected']`` forms a valid rank permutation."""
+    N = len(group)
+    sorted_ranks = sorted(list(group["selected"]))
+    expected_ranks = list(range(1, N + 1))
+    if sorted_ranks != expected_ranks:
+        print(f"Invalid rank permutation for ranker_id: {group['ranker_id'].iloc[0]}")
+        print(f"Expected: {expected_ranks}, Got: {sorted_ranks}")
+        return False
+    return True

--- a/utils.py
+++ b/utils.py
@@ -511,26 +511,8 @@ def create_remaining_features(df, is_train=True):
     df = reduce_mem_usage(df, verbose=False)
     return df
 
-def dur_stats(df):
-    for col in ['legs0_duration', 'legs1_duration']:
-        print(col,
-              "\u2192", df[col].dtype,
-              "| NaN:", df[col].isna().mean(),
-              "| 0.0:", (df[col] == 0).mean(),
-              "| -1:",  (df[col] == -1).mean(),
-              "| min:", df[col].min(),
-              "| max:", df[col].max())
-
-def check_rank_permutation(group):
-    N = len(group)
-    sorted_ranks = sorted(list(group['selected']))
-    expected_ranks = list(range(1, N + 1))
-    if sorted_ranks != expected_ranks:
-        print(f"Invalid rank permutation for ranker_id: {group['ranker_id'].iloc[0]}")
-        print(f"Expected: {expected_ranks}, Got: {sorted_ranks}")
-        return False
-    return True
-
+# Debugging helpers ``dur_stats`` and ``check_rank_permutation`` were moved to
+# :mod:`debug_utils` to keep this module focused on production utilities.
 
 def readme() -> str:
     """Return a short description of this project's purpose.


### PR DESCRIPTION
## Summary
- move debugging helpers `dur_stats` and `check_rank_permutation` out of `utils`
- create a new `debug_utils` module for these functions
- reference the new location in `utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f5bc45b483338369f2015f4abff0