### PR TITLE
Add rank-based price features

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -127,7 +127,6 @@ def prepare_matrices(train_df_processed, test_df_processed):
         'free_cancel', 'free_exchange',
         'ff_SU', 'ff_S7', 'ff_U6', 'ff_TK',
         'has_fees', 'has_baggage',
-        'price_rank', 'totalPrice_rank_in_group', 'price_from_median',
         'tax_percentage',
         'n_segments_leg0', 'n_segments_leg1',
         'group_size_log', 'has_access_tp',

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -31,3 +31,6 @@ def test_preprocess_adds_duration_pct_rank():
     assert 'duration_pct_rank' in processed.columns
     assert 'price_diff_from_median' in processed.columns
     assert 'duration_diff_from_min' in processed.columns
+    assert 'price_rank' in processed.columns
+    assert 'totalPrice_rank_in_group' in processed.columns
+    assert 'price_from_median' in processed.columns

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -148,7 +148,15 @@ def test_create_features_price_and_duration_diffs():
 
     assert 'price_diff_from_median' in out.columns
     assert 'duration_diff_from_min' in out.columns
+    assert 'price_rank' in out.columns
+    assert 'totalPrice_rank_in_group' in out.columns
+    assert 'price_from_median' in out.columns
     expected_price_diff = [-25.0, 25.0, 40.0, -40.0]
     expected_dur_diff = [0.0, 10.0, 0.0, 20.0]
+    expected_price_rank = [1.0, 2.0, 2.0, 1.0]
+    expected_rank_norm = [0.5, 1.0, 1.0, 0.5]
     assert out['price_diff_from_median'].tolist() == expected_price_diff
+    assert out['price_from_median'].tolist() == expected_price_diff
     assert out['duration_diff_from_min'].tolist() == expected_dur_diff
+    assert out['price_rank'].tolist() == expected_price_rank
+    assert out['totalPrice_rank_in_group'].tolist() == expected_rank_norm

--- a/utils.py
+++ b/utils.py
@@ -346,9 +346,15 @@ def create_features(df):
     ).astype("int8")
     feat["has_return"] = 1 - feat["is_one_way"]
     grp = df.groupby("ranker_id")
-    feat["price_pct_rank"]    = grp["totalPrice"].rank(pct=True)
-    feat["duration_rank"]     = grp["total_duration"].rank()
+    grp_sizes = grp["totalPrice"].transform("size")
+    feat["price_rank"] = grp["totalPrice"].rank(method="first")
+    feat["totalPrice_rank_in_group"] = feat["price_rank"] / grp_sizes
+    feat["price_pct_rank"] = grp["totalPrice"].rank(pct=True)
+    feat["duration_rank"] = grp["total_duration"].rank()
     feat["duration_pct_rank"] = grp["total_duration"].rank(pct=True)
+    feat["price_from_median"] = (
+        df["totalPrice"] - grp["totalPrice"].transform("median")
+    )
     feat["price_diff_from_median"] = (
         df["totalPrice"] - grp["totalPrice"].transform("median")
     )


### PR DESCRIPTION
## Summary
- compute price rank and normalized rank features
- keep rank-based columns in dataset instead of dropping them
- test that preprocessing exposes the new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f5fe346c833382896adc1414fcf3