### PR TITLE
Remove duplicate price metric, drop unused features

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -52,6 +52,33 @@ initial_core_columns += [c for c in extra_cols if c not in initial_core_columns]
 initial_core_columns = [c for c in initial_core_columns if c not in COL_BLACKLIST]
 initial_core_columns_test = [c for c in initial_core_columns if c != 'selected']
 
+# Columns that consistently have zero informational value
+NON_INFORMATIVE_COLS = [
+    'legs0_segments0_arrivalTo_airport_iata_missing',
+    'legs0_segments0_baggageAllowance_quantity_missing',
+    'legs1_departureAt_month',
+    'legs1_segments0_baggageAllowance_quantity_missing',
+    'sex',
+    'legs1_departureAt_quarter',
+    'total_segments',
+    'legs0_departureAt_quarter',
+    'legs0_departureAt_month',
+    'requestDate_quarter',
+    'requestDate_month',
+    'requestDate_dow',
+    'requestDate_hour',
+    'is_popular_route',
+    'group_size',
+    'is_vip_freq',
+    'is_direct_leg0',
+    'isVip',
+    'legs1_departureAt_weekday',
+    'frequentFlyer',
+    'legs0_departureAt_weekday',
+    'n_ff_programs',
+    'nationality',
+]
+
 
 def load_data(sample_frac=0.5, random_seed=42):
     print("Loading a subset of columns for train_df...")
@@ -115,6 +142,8 @@ def preprocess_dataframe(df, is_train=True):
     gc.collect()
     df = unify_nan_strategy(df)
     gc.collect()
+    df.drop(columns=[c for c in NON_INFORMATIVE_COLS if c in df.columns],
+            inplace=True, errors="ignore")
     log_mem_usage(df, f"{'train' if is_train else 'test'} after unify")
     df = reduce_mem_usage(df)
     gc.collect()
@@ -144,7 +173,7 @@ def prepare_matrices(train_df_processed, test_df_processed):
         'n_segments_leg0', 'n_segments_leg1',
         'group_size_log', 'has_access_tp',
         'is_round_trip',
-    ]
+    ] + [c for c in NON_INFORMATIVE_COLS if c not in COL_BLACKLIST]
     train_df_processed.drop(
         columns=[c for c in DROP_COLS if c in train_df_processed.columns],
         inplace=True,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -29,7 +29,6 @@ def test_preprocess_adds_duration_pct_rank():
 
     processed = pipeline.preprocess_dataframe(df.copy(), is_train=True)
     assert 'duration_pct_rank' in processed.columns
-    assert 'price_diff_from_median' in processed.columns
     assert 'duration_diff_from_min' in processed.columns
     assert 'price_rank' in processed.columns
     assert 'totalPrice_rank_in_group' in processed.columns

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,7 +146,6 @@ def test_create_features_price_and_duration_diffs():
 
     out = utils.create_features(df.copy())
 
-    assert 'price_diff_from_median' in out.columns
     assert 'duration_diff_from_min' in out.columns
     assert 'price_rank' in out.columns
     assert 'totalPrice_rank_in_group' in out.columns
@@ -155,7 +154,6 @@ def test_create_features_price_and_duration_diffs():
     expected_dur_diff = [0.0, 10.0, 0.0, 20.0]
     expected_price_rank = [1.0, 2.0, 2.0, 1.0]
     expected_rank_norm = [0.5, 1.0, 1.0, 0.5]
-    assert out['price_diff_from_median'].tolist() == expected_price_diff
     assert out['price_from_median'].tolist() == expected_price_diff
     assert out['duration_diff_from_min'].tolist() == expected_dur_diff
     assert out['price_rank'].tolist() == expected_price_rank

--- a/utils.py
+++ b/utils.py
@@ -371,9 +371,6 @@ def create_features(df):
     feat["price_from_median"] = (
         df["totalPrice"] - grp["totalPrice"].transform("median")
     )
-    feat["price_diff_from_median"] = (
-        df["totalPrice"] - grp["totalPrice"].transform("median")
-    )
     feat["duration_diff_from_min"] = (
         df["total_duration"] - grp["total_duration"].transform("min")
     )


### PR DESCRIPTION
## Summary
- dedupe `price_diff_from_median` feature generation
- trim low-value columns while preprocessing
- update feature drop list
- adjust tests for removed feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682f29fe188333a8cdeac020051d55