### PR TITLE
Drop taxes when highly correlated

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -160,6 +160,19 @@ def prepare_matrices(train_df_processed, test_df_processed):
     for df in (train_df_processed, test_df_processed):
         df['dep_is_hub'] = df[airport_col].isin(top_hubs).astype('int8')
 
+    # Check correlation between taxes and price-based features
+    corr_thresh = 0.95
+    if {
+        'taxes',
+        'price_from_median'
+    }.issubset(train_df_processed.columns):
+        corr_val = train_df_processed['taxes'].corr(
+            train_df_processed['price_from_median']
+        )
+        if pd.notna(corr_val) and abs(corr_val) > corr_thresh:
+            train_df_processed.drop(columns=['taxes'], inplace=True)
+            test_df_processed.drop(columns=['taxes'], inplace=True, errors='ignore')
+
     raw_datetime_col_names = [
         'requestDate', 'legs0_departureAt', 'legs0_arrivalAt',
         'legs1_departureAt', 'legs1_arrivalAt'

--- a/tests/test_prepare_matrices.py
+++ b/tests/test_prepare_matrices.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import pipeline
+
+def test_prepare_matrices_drops_high_corr_taxes():
+    train_df = pd.DataFrame({
+        'Id': [1, 2, 3, 4],
+        'ranker_id': [1, 1, 2, 2],
+        'selected': [0, 1, 0, 1],
+        'profileId': [0, 0, 0, 0],
+        'companyID': [1, 1, 1, 1],
+        'searchRoute': ['A', 'A', 'B', 'B'],
+        'legs0_segments0_departureFrom_airport_iata': ['SFO', 'LAX', 'SFO', 'LAX'],
+        'requestDate': pd.to_datetime(['2024-01-01'] * 4),
+        'legs0_departureAt': pd.to_datetime(['2024-01-02'] * 4),
+        'legs0_arrivalAt': pd.to_datetime(['2024-01-02 01:00'] * 4),
+        'legs1_departureAt': pd.to_datetime(['2024-01-02'] * 4),
+        'legs1_arrivalAt': pd.to_datetime(['2024-01-02 03:00'] * 4),
+        'taxes': [10.0, 20.0, 30.0, 40.0],
+        'totalPrice': [100.0, 200.0, 300.0, 400.0],
+        'price_from_median': [10.0, 20.0, 30.0, 40.0],
+    })
+    test_df = train_df.drop(columns=['selected'])
+
+    X, y, X_test, _ = pipeline.prepare_matrices(train_df.copy(), test_df.copy())
+
+    assert 'taxes' not in X.columns
+    assert 'taxes' not in X_test.columns


### PR DESCRIPTION
## Summary
- drop the `taxes` column in `prepare_matrices` when its correlation with `price_from_median` exceeds 0.95
- test that the column is removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686856b54ee083338d5145082aa4c725