### PR TITLE
Add GPU training indicator

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -338,6 +338,9 @@ def train_model(X, y, X_test, ranker_ids, cat_features, params=None, n_folds=5):
         params.setdefault("device", "gpu")
         params.setdefault("gpu_platform_id", 0)
         params.setdefault("gpu_device_id", 0)
+        print("Training with GPU")
+    else:
+        print("Training with CPU")
     group_kfold = GroupKFold(n_splits=n_folds)
     oof_preds_scores = np.zeros(len(X))
     test_preds_scores = np.zeros(len(X_test))


### PR DESCRIPTION
## Summary
- add console output for GPU or CPU training in `train_model`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710c286d7083339d70e9888e5b974c