### PR TITLE
Remove unused import

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -2,7 +2,6 @@ import pandas as pd
 import numpy as np
 import lightgbm as lgb
 from sklearn.model_selection import GroupKFold
-from sklearn.preprocessing import LabelEncoder
 import gc
 import os
 


### PR DESCRIPTION
## Summary
- cleanup: remove an unused `LabelEncoder` import from `pipeline.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871135a4880833387335d511b5b3dbf