### PR TITLE
Handle missing LightGBM GPU

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -334,12 +334,30 @@ def train_model(X, y, X_test, ranker_ids, cat_features, params=None, n_folds=5):
         }
     # Allow optional GPU training when USE_GPU=1 or Kaggle exposes NVIDIA_VISIBLE_DEVICES
     use_gpu = os.getenv("USE_GPU", "0") == "1" or "NVIDIA_VISIBLE_DEVICES" in os.environ
+    gpu_supported = False
     if use_gpu:
+        try:
+            # LightGBM 4.1+ exposes get_device_name when compiled with GPU
+            if hasattr(lgb, "get_device_name"):
+                lgb.get_device_name(0)
+            else:
+                raise AttributeError
+            gpu_supported = True
+        except Exception:
+            print(
+                "Warning: GPU requested but unavailable; falling back to CPU."
+            )
+            use_gpu = False
+    if use_gpu and gpu_supported:
         params.setdefault("device", "gpu")
         params.setdefault("gpu_platform_id", 0)
         params.setdefault("gpu_device_id", 0)
         print("Training with GPU")
     else:
+        # ensure no stale GPU params remain
+        params.pop("device", None)
+        params.pop("gpu_platform_id", None)
+        params.pop("gpu_device_id", None)
         print("Training with CPU")
     group_kfold = GroupKFold(n_splits=n_folds)
     oof_preds_scores = np.zeros(len(X))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -83,3 +83,32 @@ def test_encode_categoricals_frequency_encoding():
 
     assert np.allclose(X_enc['legs0_segments0_departureFrom_airport_iata'].values, expected_train.values)
     assert np.allclose(X_test_enc['legs0_segments0_departureFrom_airport_iata'].values, expected_test.values)
+
+
+def test_train_model_falls_back_to_cpu_when_gpu_unavailable(capsys):
+    X = pd.DataFrame({'f': [1, 2]})
+    y = pd.Series([0, 1])
+    X_test = pd.DataFrame({'f': [3]})
+    ranks = pd.Series([1, 2])
+
+    class DummyBooster:
+        def __init__(self, n_features):
+            self.n_features = n_features
+        def feature_importance(self, importance_type='gain'):
+            return np.zeros(self.n_features)
+
+    class DummyRanker:
+        def __init__(self, **params):
+            pass
+        def fit(self, X, y, **kwargs):
+            self.booster_ = DummyBooster(X.shape[1])
+        def predict(self, X):
+            return np.zeros(len(X))
+
+    with patch.dict('os.environ', {'USE_GPU': '1'}), \
+         patch('pipeline.lgb.get_device_name', side_effect=Exception('no gpu'), create=True), \
+         patch('pipeline.lgb.LGBMRanker', DummyRanker):
+        pipeline.train_model(X, y, X_test, ranks, [], params={'n_estimators': 1}, n_folds=2)
+
+    out = capsys.readouterr().out.lower()
+    assert 'falling back to cpu' in out


### PR DESCRIPTION
## Summary
- detect GPU support for LightGBM in `train_model`
- gracefully fall back to CPU when GPU not available
- test fallback behaviour when GPU is requested but unsupported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687115147e248333913c9e8f889178d7