### PR TITLE
Support corr_thresh in prepare_matrices

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -156,7 +156,7 @@ def preprocess_dataframe(df, is_train=True):
     log_mem_usage(df, f"{'train' if is_train else 'test'} final")
     return df
 
-def prepare_matrices(train_df_processed, test_df_processed, drop_cols=None):
+def prepare_matrices(train_df_processed, test_df_processed, drop_cols=None, corr_thresh=0.95):
     TOP_N = 10
     airport_col = 'legs0_segments0_departureFrom_airport_iata'
     freq = train_df_processed[airport_col].value_counts()
@@ -167,7 +167,6 @@ def prepare_matrices(train_df_processed, test_df_processed, drop_cols=None):
         df['dep_is_hub'] = df[airport_col].isin(top_hubs).astype('int8')
 
     # Check correlation between taxes and price-based features
-    corr_thresh = 0.95
     if {
         'taxes',
         'price_from_median'

--- a/tests/test_prepare_matrices.py
+++ b/tests/test_prepare_matrices.py
@@ -27,3 +27,29 @@ def test_prepare_matrices_drops_high_corr_taxes():
 
     assert 'taxes' not in X.columns
     assert 'taxes' not in X_test.columns
+
+
+def test_prepare_matrices_uses_corr_thresh_parameter():
+    train_df = pd.DataFrame({
+        'Id': [1, 2, 3, 4],
+        'ranker_id': [1, 1, 2, 2],
+        'selected': [0, 1, 0, 1],
+        'profileId': [0, 0, 0, 0],
+        'companyID': [1, 1, 1, 1],
+        'searchRoute': ['A', 'A', 'B', 'B'],
+        'legs0_segments0_departureFrom_airport_iata': ['SFO', 'LAX', 'SFO', 'LAX'],
+        'requestDate': pd.to_datetime(['2024-01-01'] * 4),
+        'legs0_departureAt': pd.to_datetime(['2024-01-02'] * 4),
+        'legs0_arrivalAt': pd.to_datetime(['2024-01-02 01:00'] * 4),
+        'legs1_departureAt': pd.to_datetime(['2024-01-02'] * 4),
+        'legs1_arrivalAt': pd.to_datetime(['2024-01-02 03:00'] * 4),
+        'taxes': [10.0, 20.0, 30.0, 40.0],
+        'totalPrice': [100.0, 200.0, 300.0, 400.0],
+        'price_from_median': [10.0, 20.0, 30.0, 40.0],
+    })
+    test_df = train_df.drop(columns=['selected'])
+
+    X, _, X_test, _ = pipeline.prepare_matrices(train_df.copy(), test_df.copy(), corr_thresh=1.0)
+
+    assert 'taxes' in X.columns
+    assert 'taxes' in X_test.columns


### PR DESCRIPTION
## Summary
- accept a `corr_thresh` argument in `pipeline.prepare_matrices`
- use the parameter instead of a constant
- test that the value can be overridden

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e7cc036483339ad98b2ef0b3806c