### PR TITLE
Remove unused notebook variable

### DIFF
--- a/2-7version.ipynb
+++ b/2-7version.ipynb
@@ -108,7 +108,6 @@
     "SAMPLE_FRAC = 0.5  # fraction of groups to load\n",
     "LOW_VAR_THRESH = 1  # drop columns with <= this many unique values\n",
     "COLINEAR_THRESH = 0.95  # correlation threshold for dropping columns\n",
-    "useCPU = 1\n",
     "\n",
     "# Columns to drop when preparing training matrices\n",
     "DROP_COLS = [\n",


### PR DESCRIPTION
## Summary
- delete unused `useCPU` assignment from the training notebook

## Testing
- `pytest -q`
- `python - <<'EOF'
import nbformat; nbformat.read('2-7version.ipynb', as_version=4)
print('valid')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687316075e248333adfebcb5b7fee0b1