### PR TITLE
Fix deprecated categorical dtype check

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -124,7 +124,7 @@ def preprocess_dataframe(df, is_train=True):
     obj_cols = df.select_dtypes('object').columns
     for c in obj_cols:
         df[c] = df[c].astype('category')
-    if 'frequentFlyer' in df.columns and pd.api.types.is_categorical_dtype(df['frequentFlyer']):
+    if 'frequentFlyer' in df.columns and isinstance(df['frequentFlyer'].dtype, pd.CategoricalDtype):
         df['frequentFlyer'] = df['frequentFlyer'].cat.add_categories(['']).fillna('')
     del obj_cols
     gc.collect()

--- a/utils.py
+++ b/utils.py
@@ -428,7 +428,7 @@ def create_features(df):
     del feat, seg_counts, present_airlines, ff_flags, ff, grp, grp_sizes
     gc.collect()
     for col in df.select_dtypes(include="object").columns:
-        if pd.api.types.is_categorical_dtype(df[col]):
+        if isinstance(df[col].dtype, pd.CategoricalDtype):
             if "missing" not in df[col].cat.categories:
                 df[col] = df[col].cat.add_categories(["missing"])
                 df[col] = df[col].fillna("missing")


### PR DESCRIPTION
## Summary
- eliminate deprecated `pd.api.types.is_categorical_dtype` usage
- use `isinstance(..., pd.CategoricalDtype)` per pandas recommendation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873161ee7b883338cb177396244a4b0